### PR TITLE
Separate Prettier and Jest configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ website/static/lib
 /test-results/
 /playwright-report/
 /playwright/.cache/
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+/** @type {import('jest').Config} */
+const config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/.jest/setup.js'],
+  testPathIgnorePatterns: ['/node_modules/', '/build/', '/src/modules/'],
+  moduleNameMapper: {
+    '^d3$': '<rootDir>/node_modules/d3/dist/d3.min.js',
+    '^.+\\.css\\?raw': '<rootDir>/.jest/CSSStub.js',
+  },
+  collectCoverageFrom: ['src/**/*.ts', '!**/build/**', '!**/vendor/**', '!src/modules/**'],
+  coverageReporters: ['json', 'html', 'lcov'],
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -84,38 +84,5 @@
     "typedoc": "0.25.4",
     "typedoc-plugin-missing-exports": "2.1.0",
     "typescript": "5.3.3"
-  },
-  "prettier": {
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "all",
-    "printWidth": 100
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "jsdom",
-    "setupFiles": [
-      "<rootDir>/.jest/setup.js"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/build/",
-      "/src/modules/"
-    ],
-    "moduleNameMapper": {
-      "^d3$": "<rootDir>/node_modules/d3/dist/d3.min.js",
-      "^.+\\.css\\?raw": "<rootDir>/.jest/CSSStub.js"
-    },
-    "collectCoverageFrom": [
-      "src/**/*.ts",
-      "!**/build/**",
-      "!**/vendor/**",
-      "!src/modules/**"
-    ],
-    "coverageReporters": [
-      "json",
-      "html",
-      "lcov"
-    ]
   }
 }


### PR DESCRIPTION
### Changes
- Move Prettier configuration to .prettierrc 
- Move Jest configuration to jest.config.js
- Updated .gitignore to ignore pnpm-lock.yaml

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Organizes configuration files

**What is the current behavior?** (You can also link to an open issue here)
The same current behavior.


**What is the new behavior (if this is a feature change)?**
No new behavior.


**Other information**:
No changes to functionality or features; this PR simply organizes configuration files and updates the .gitignore.