### PR TITLE
Automate release

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,6 +7,9 @@
 - **Summary**
 
 - **Link to minimal reproduction**
-  (please provide a link to a minimal reproduction of the issue e.g. on https://livecodes.io)
+  <!--
+  please provide a link to a minimal reproduction of the issue e.g. on https://livecodes.io
+  You may use this as a starting point: https://livecodes.io/?x=id/6sdjrf25i67
+  -->
 
 - **Other information** (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. StackOverflow, personal fork, etc.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,17 @@
-* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 
+- **What is the current behavior?** (You can also link to an open issue here)
 
+- **What is the new behavior (if this is a feature change)?**
 
-* **What is the current behavior?** (You can also link to an open issue here)
+- **Issue related to this PR**
+  <!--
+  please make sure that these changes have been discussed and approved in an issue.
+  Otherwise, please do: https://github.com/hatemhosny/racing-bars/issues/new
+  -->
 
+  [ ] The changes have been discussed in an issue and the approach has been approved.
 
+  issue:
 
-* **What is the new behavior (if this is a feature change)?**
-
-
-
-* **Other information**:
+- **Other information**:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,24 @@
+name: Release PR
+
+# on creating a release branch (releases/**) create a PR to main
+
+on: create
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'refs/heads/releases/')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_ACTIONS_REPO_PAT }}
+
+      - name: Get version
+        id: vars
+        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^releases\///')
+
+      - name: Create pull request to main
+        run: gh pr create --title "Prepare release ${{steps.vars.outputs.version}}" --body "Prepare release ${{steps.vars.outputs.version}}" --base main --head "${{github.ref_name}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_REPO_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+# on merging a release branch (releases/**) to main:
+# - create a GitHub release (with release notes and attached files)
+# - create a tag
+# - publish to npm
+# - create a pull request to develop to incorporate back the changes
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged && startsWith(github.head_ref, 'releases/')
+    env:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_ACTIONS_REPO_PAT }}
+
+      - name: Get version
+        id: vars
+        run: echo ::set-output name=version::$(echo ${{github.head_ref}} | sed 's/^releases\///')
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '18.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test
+
+      - name: Release notes
+        run: node ./scripts/release-notes.js
+
+      - name: Create tag
+        run: git tag ${{steps.vars.outputs.version}} && git push origin --tags
+
+      - name: Compress build directory (tar)
+        run: tar -czf racing-bars-${{steps.vars.outputs.version}}.tar.gz build
+
+      - name: Compress build directory (zip)
+        uses: vimtor/action-zip@v1
+        with:
+          files: build/
+          dest: racing-bars-${{steps.vars.outputs.version}}.zip
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{steps.vars.outputs.version}}
+          tag_name: ${{steps.vars.outputs.version}}
+          body_path: CHANGELOG.tmp.md
+          files: |
+            racing-bars-${{steps.vars.outputs.version}}.tar.gz
+            racing-bars-${{steps.vars.outputs.version}}.zip
+          token: ${{ secrets.GH_ACTIONS_REPO_PAT }}
+
+      - name: Publish to NPM
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          npm publish --access=public
+        working-directory: ./build
+        env:
+          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - name: Create a pull request to develop
+        if: startsWith(github.head_ref, 'releases/v')
+        run: gh pr create --title "release ${{steps.vars.outputs.version}}" --body "https://www.npmjs.com/package/racing-bars" --base develop --head main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_REPO_PAT }}

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "postinstall": "cd website && npm install",
     "reset": "git clean -dfx && git reset --hard && npm i",
     "clean": "recursive-delete build && recursive-delete tmp && recursive-delete website/build && recursive-delete website/static/data && recursive-delete website/docs/api",
-    "release-notes": "node ./scripts/prepare-release.mjs",
-    "prepare-release": "run-s release-notes build test"
+    "start-release": "node ./scripts/start-release.mjs"
   },
   "dependencies": {
     "d3": "7.9.0"

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const path = require('path');
+
+const changelog = fs.readFileSync(path.resolve('./CHANGELOG.md'), 'utf8');
+const changelogSeparator = '\n---';
+const [_changelogHeader, releaseLog, ..._prevLog] = changelog.split(changelogSeparator);
+fs.writeFileSync(path.resolve('./CHANGELOG.tmp.md'), releaseLog, 'utf8');

--- a/scripts/start-release.mjs
+++ b/scripts/start-release.mjs
@@ -4,6 +4,7 @@ import conventionalChangelog from 'conventional-changelog';
 import fs from 'fs';
 import { execSync } from 'child_process';
 import { createRequire } from 'module';
+
 const require = createRequire(import.meta.url);
 const pkgPath = '../src/package.lib.json';
 const changelogPath = '../CHANGELOG.md';
@@ -80,7 +81,7 @@ const stringify = (obj) => JSON.stringify(obj, null, 2) + '\n';
 
 const cancelRelease = async () => {
   if (await confirm({ message: 'Cancelling release. Do you want to discard all changes?' })) {
-    execSync(`git reset --hard && git clean -fxd`);
+    execSync(`git reset --hard`);
   }
   console.log('Release cancelled!');
   process.exit(1);
@@ -88,9 +89,9 @@ const cancelRelease = async () => {
 
 (async () => {
   const libBump = await getBump();
-  const version = libBump === 'specify' ? await getVersion() : bumpVersion(libBump);
-  pkg.version = version;
-  if (!(await confirm({ message: `Creating library version: ${version}\nProceed?` }))) {
+  pkg.version = libBump === 'specify' ? await getVersion() : bumpVersion(libBump);
+  const version = 'v' + pkg.version;
+  if (!(await confirm({ message: `Creating version: ${version}\nProceed?` }))) {
     await cancelRelease();
   }
   fs.writeFileSync(new URL(pkgPath, import.meta.url), stringify(pkg), 'utf8');
@@ -113,6 +114,11 @@ const cancelRelease = async () => {
   if (!(await confirm({ message: `Change log added to ./CHANGELOG.md\nProceed?` }))) {
     await cancelRelease();
   }
+
+  const branchName = 'releases/' + version;
+  execSync(`git checkout -b ${branchName}`);
+  execSync(`git add -A && git commit -m "release: ${version}"`);
+  execSync(`git push -u origin ${branchName}`);
 })();
 
 function streamToString(stream) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

Currently the library is manually released and published to npm.

* **What is the new behavior (if this is a feature change)?**

This PR automates the process of releasing a new version.
This is a description:

- Start on the branch `develop` with no uncommitted changes.
- run `npm run start-release`
- follow instructions/prompts in cli:
  - select the new version -> added to "src/package.lib.json"
  - release notes are automatically generated and added to "CHANGELOG.md". More changes can be added manually before proceeding
  - once approved a new branch is created (releases/v*), release changes are committed and the branch is pushed.
- On pushing a release branch, a PR is automatically created to `main` branch.
- On merging a release branch to main:
  - A GitHub release is created (with release notes and attached files)
  - A tag is created and pushed
  - The package is published to npm
  - A PR to "develop" is created to incorporate back the changes

* **Other information**:
