### PR TITLE
Fix worker multiple messages

### DIFF
--- a/src/lib/utils/data.ts
+++ b/src/lib/utils/data.ts
@@ -31,11 +31,13 @@ export async function prepareData(
     messageId,
   });
   const preparedData = await new Promise<Data[]>((resolve) => {
-    worker.addEventListener('message', (event) => {
+    const onMessage = (event: MessageEvent) => {
       if (event.data.type === 'data-prepared' && event.data.messageId === messageId) {
         resolve(event.data.data);
+        worker.removeEventListener('message', onMessage);
       }
-    });
+    };
+    worker.addEventListener('message', onMessage);
   });
   storeDataCollections(preparedData, store, changingOptions);
   return preparedData;

--- a/src/lib/utils/data.ts
+++ b/src/lib/utils/data.ts
@@ -6,7 +6,7 @@ import { loadData } from '../load-data';
 // eslint-disable-next-line import/no-internal-modules
 import workerSrc from '../../../tmp/racing-bars.worker.js';
 import { getDates, getNextDate } from './dates';
-import { createWorkerFromContent } from './utils';
+import { createWorkerFromContent, generateId } from './utils';
 
 const worker = createWorkerFromContent(workerSrc);
 
@@ -22,22 +22,20 @@ export async function prepareData(
     }
     data = dataTransform(await data);
   }
+  const messageId = generateId();
   worker.postMessage({
     type: 'prepare-data',
     data,
     options: removeFnOptions(store.getState().options),
     baseUrl: location.href,
+    messageId,
   });
   const preparedData = await new Promise<Data[]>((resolve) => {
-    worker.addEventListener(
-      'message',
-      (event) => {
-        if (event.data.type === 'data-prepared') {
-          resolve(event.data.data);
-        }
-      },
-      { once: true },
-    );
+    worker.addEventListener('message', (event) => {
+      if (event.data.type === 'data-prepared' && event.data.messageId === messageId) {
+        resolve(event.data.data);
+      }
+    });
   });
   storeDataCollections(preparedData, store, changingOptions);
   return preparedData;

--- a/src/lib/worker/index.ts
+++ b/src/lib/worker/index.ts
@@ -3,9 +3,9 @@ import { prepareData } from './prepare-data';
 const worker: Worker = self as any as Worker;
 
 worker.addEventListener('message', async (event) => {
-  const { type, data, options, baseUrl } = event.data;
+  const { type, data, options, baseUrl, messageId } = event.data;
   if (type === 'prepare-data') {
     const result = await prepareData(data, options, baseUrl);
-    worker.postMessage({ type: 'data-prepared', data: result });
+    worker.postMessage({ type: 'data-prepared', data: result, messageId });
   }
 });

--- a/website/docs/guides/multiple-charts.md
+++ b/website/docs/guides/multiple-charts.md
@@ -14,7 +14,7 @@ Example:
 
 <div className="gallery">
   <RacingBars
-    dataUrl="/data/population.csv"
+    dataUrl="/data/brands.csv"
     dataType="csv"
     title="Chart 1"
     labelsPosition="outside"

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -35,7 +35,6 @@ icon: `https://flagsapi.com/${d.code}/flat/64.png`,
 <div className="gallery">
   <RacingBars
     style={{width: 800, height: 450}}
-
     dataUrl="/data/population.csv"
     dataType="csv"
     dataTransform={transformFn}
@@ -57,7 +56,5 @@ icon: `https://flagsapi.com/${d.code}/flat/64.png`,
       ...d,
       icon: \`https://flagsapi.com/\${d.code}/flat/64.png\`,
     }))`}}
-
 />
-
 </div>

--- a/website/static/_headers
+++ b/website/static/_headers
@@ -1,0 +1,2 @@
+/*
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix

**What is the current behavior?**

When multiple charts in the same page send data to the web worker, they may mix prepared data when received back depending on the order.

**What is the new behavior (if this is a feature change)?**

Now the chart sends a unique `messageId` to the worker and only accepts data with this id.
