### PR TITLE
auto detect dataShape and dataType

### DIFF
--- a/src/lib/load-data.ts
+++ b/src/lib/load-data.ts
@@ -1,14 +1,30 @@
 import { json, csv, tsv, xml } from './d3';
-import type { Data, WideData } from './data';
+import type { Options, Data, WideData } from './index';
 
 export function loadData(
   url: string,
-  type: 'json' | 'csv' | 'tsv' | 'xml' = 'json',
+  type: Options['dataType'] = 'auto',
 ): Promise<Data[]> | Promise<WideData[]> {
+  const supportedTypes: Array<Exclude<Options['dataType'], 'auto'>> = ['json', 'csv', 'tsv', 'xml'];
+  const isSupported = (t: any) => supportedTypes.includes(t);
+
+  const detectDataType = () => {
+    const t = type.toLowerCase();
+    if (isSupported(t)) {
+      return t;
+    }
+    const extension = url.split('.').pop()?.toLowerCase() || '';
+    if (isSupported(extension)) {
+      return extension;
+    }
+    return 'json';
+  };
+
   const handleError = () => {
     throw new Error(`Failed to load data as ${type.toUpperCase()} from ${url}`);
   };
-  switch (type) {
+
+  switch (detectDataType()) {
     case 'json':
       return json(url).catch(handleError) as Promise<Data[]> | Promise<WideData[]>;
     case 'csv':

--- a/src/lib/options/options.models.ts
+++ b/src/lib/options/options.models.ts
@@ -7,7 +7,7 @@ export interface OptionsAction extends Action {
 
 export interface Options {
   dataShape: 'long' | 'wide';
-  dataType: 'json' | 'csv' | 'tsv' | 'xml';
+  dataType: 'json' | 'csv' | 'tsv' | 'xml' | 'auto';
   dataTransform: null | ((data: Data[] | WideData[]) => Data[] | WideData[]);
   fillDateGapsInterval: null | 'year' | 'month' | 'day';
   fillDateGapsValue: 'last' | 'interpolate';

--- a/src/lib/options/options.models.ts
+++ b/src/lib/options/options.models.ts
@@ -6,7 +6,7 @@ export interface OptionsAction extends Action {
 }
 
 export interface Options {
-  dataShape: 'long' | 'wide';
+  dataShape: 'long' | 'wide' | 'auto';
   dataType: 'json' | 'csv' | 'tsv' | 'xml' | 'auto';
   dataTransform: null | ((data: Data[] | WideData[]) => Data[] | WideData[]);
   fillDateGapsInterval: null | 'year' | 'month' | 'day';

--- a/src/lib/options/options.reducer.ts
+++ b/src/lib/options/options.reducer.ts
@@ -5,7 +5,7 @@ import { actionTypes } from './options.actions';
 
 export const defaultOptions: Options = {
   dataShape: 'long',
-  dataType: 'json',
+  dataType: 'auto',
   dataTransform: null,
   fillDateGapsInterval: null,
   fillDateGapsValue: 'interpolate',

--- a/src/lib/options/options.reducer.ts
+++ b/src/lib/options/options.reducer.ts
@@ -4,7 +4,7 @@ import type { Options, OptionsAction } from './options.models';
 import { actionTypes } from './options.actions';
 
 export const defaultOptions: Options = {
-  dataShape: 'long',
+  dataShape: 'auto',
   dataType: 'auto',
   dataTransform: null,
   fillDateGapsInterval: null,

--- a/src/lib/worker/prepare-data.ts
+++ b/src/lib/worker/prepare-data.ts
@@ -12,6 +12,7 @@ export function prepareData(
   baseUrl: string,
 ): Promise<Data[]> {
   return fetchData(data, options.dataType, baseUrl)
+    .then(handleEmptyData)
     .then(filterByDate(options.startDate, options.endDate))
     .then(wideDataToLong(options.dataShape))
     .then(processFixedOrder(options.fixedOrder))
@@ -41,6 +42,12 @@ function fetchData(
 
 function isRelativeUrl(url: string) {
   return !url.startsWith('https://') && !url.startsWith('http://') && !url.startsWith('data:');
+}
+
+function handleEmptyData(data: Data[] | WideData[]): Data[] | WideData[] {
+  return !Array.isArray(data) || data.length === 0
+    ? [{ date: getDateString(new Date()), value: 0, name: '' }]
+    : data;
 }
 
 function filterByDate(startDate: string, endDate: string) {

--- a/src/lib/worker/prepare-data.ts
+++ b/src/lib/worker/prepare-data.ts
@@ -22,7 +22,7 @@ export function prepareData(
 
 function fetchData(
   data: Data[] | WideData[] | Promise<Data[]> | Promise<WideData[]> | string,
-  dataType: 'json' | 'csv' | 'tsv' | 'xml',
+  dataType: Options['dataType'],
   baseUrl: string,
 ) {
   if (typeof data === 'string') {

--- a/src/lib/worker/prepare-data.ts
+++ b/src/lib/worker/prepare-data.ts
@@ -114,9 +114,20 @@ function calculateLastValues(makeCumulative = false) {
   };
 }
 
+function detectDataShape(data: Data[] | WideData[], dataShape: Options['dataShape']) {
+  if (dataShape === 'long' || dataShape === 'wide') return dataShape;
+  const firstRow = data[0];
+  if ('date' in firstRow && 'name' in firstRow && 'value' in firstRow) {
+    return 'long';
+  }
+  return 'wide';
+}
+
 function wideDataToLong(dataShape: Options['dataShape'], nested = false) {
   return function (data: WideData[]) {
-    if (dataShape === 'long') return data as Data[];
+    if (dataShape === 'long' || detectDataShape(data, dataShape) === 'long') {
+      return data as Data[];
+    }
 
     const long = [] as Data[];
     data.forEach((row) => {

--- a/website/docs/documentation/data.md
+++ b/website/docs/documentation/data.md
@@ -142,7 +142,9 @@ race(data, '#race');
 #### Load data from URL
 
 Data can be loaded from a URL. The following formats are supported:
-`json` (default), `csv`, `tsv` and `xml`.
+`json`, `csv`, `tsv` and `xml`.
+
+Data type is automatically detected by file extension, otherwise `json` is assumed.
 
 - Load JSON from URL
 
@@ -216,7 +218,7 @@ date,Canada,Egypt,Greece,Panama,Singapore
 
 ### Usage
 
-For wide data to be processed, the [`options`](./options.md) object should have the field [`dataShape`](./options.md#datashape) set to `"wide"`
+For wide data to be processed, the [`options`](./options.md) object should have the field [`dataShape`](./options.md#datashape) set (or auto-detected) to `"wide"`
 
 - JS array of objects
 
@@ -281,70 +283,70 @@ Example for long data with [optional fields](#long-data):
     "date": "2017-01-01",
     "name": "Egypt",
     "value": 96.44,
-    "icon": "https://www.countryflags.io/eg/flat/64.png",
+    "icon": "https://flagsapi.com/EG/flat/64.png",
     "group": "Africa"
   },
   {
     "date": "2017-01-01",
     "name": "Singapore",
     "value": 5.61,
-    "icon": "https://www.countryflags.io/sg/flat/64.png",
+    "icon": "https://flagsapi.com/SG/flat/64.png",
     "group": "Asia"
   },
   {
     "date": "2017-01-01",
     "name": "Greece",
     "value": 10.75,
-    "icon": "https://www.countryflags.io/gr/flat/64.png",
+    "icon": "https://flagsapi.com/GR/flat/64.png",
     "group": "Europe"
   },
   {
     "date": "2017-01-01",
     "name": "Panama",
     "value": 4.11,
-    "icon": "https://www.countryflags.io/pa/flat/64.png",
+    "icon": "https://flagsapi.com/PA/flat/64.png",
     "group": "North America"
   },
   {
     "date": "2018-01-01",
     "name": "Greece",
     "value": 10.73,
-    "icon": "https://www.countryflags.io/gr/flat/64.png",
+    "icon": "https://flagsapi.com/GR/flat/64.png",
     "group": "Europe"
   },
   {
     "date": "2018-01-01",
     "name": "Singapore",
     "value": 5.64,
-    "icon": "https://www.countryflags.io/sg/flat/64.png",
+    "icon": "https://flagsapi.com/SG/flat/64.png",
     "group": "Asia"
   },
   {
     "date": "2018-01-01",
     "name": "Canada",
     "value": 37.06,
-    "icon": "https://www.countryflags.io/ca/flat/64.png",
+    "icon": "https://flagsapi.com/CA/flat/64.png",
     "group": "North America"
   },
   {
     "date": "2018-01-01",
     "name": "Egypt",
     "value": 98.42,
-    "icon": "https://www.countryflags.io/eg/flat/64.png",
+    "icon": "https://flagsapi.com/EG/flat/64.png",
     "group": "Africa"
   },
   {
     "date": "2017-01-01",
     "name": "Canada",
     "value": 36.54,
-    "icon": "https://www.countryflags.io/ca/flat/64.png",
+    "icon": "https://flagsapi.com/CA/flat/64.png",
     "group": "North America"
   },
   {
     "date": "2018-01-01",
     "name": "Panama",
     "value": 4.18,
-    "icon": "https://www.countryflags.io/pa/flat/64.png",
+    "icon": "https://flagsapi.com/PA/flat/64.png",
     "group": "North America"
   }
 ]

--- a/website/docs/documentation/options.md
+++ b/website/docs/documentation/options.md
@@ -175,11 +175,11 @@ See the guide on [`chart controls`](../guides/chart-controls.md) for other alter
 
 ### dataShape
 
-Instruction whether the data shape is <a href="https://en.wikipedia.org/wiki/Wide_and_narrow_data" target="_blank">"long" or "wide"</a>.
+Instruction whether the data shape is <a href="https://en.wikipedia.org/wiki/Wide_and_narrow_data" target="_blank">"long" or "wide"</a>. By default, the library tries to detect the data shape automatically from its structure (after any [transformation](#dataTransform), by finding the columns `date`, `name` and `value`). If the data shape is not detected correctly, it can be manually specified.  
 See ["Data" section](./data.md) for more details and examples.
 
-- Type: `"long" | "wide"`
-- Default: `"long"`
+- Type: `"long" | "wide" | "auto"`
+- Default: `"auto"`
 - Example:
 
 This example uses `"wide"` data shape
@@ -243,17 +243,18 @@ So it would be more convenient to be able to also pass a transformation function
 
 ### dataType
 
-When a URL to a file containing the data is supplied as the first argument to the [`race`](./api.md#race) function,
-the type of that file can be specified using the `"dataType"` option.
+When a URL to a file containing the data is supplied as the first argument to the [`race`](./api.md#race) function, the type of that file can be specified using the `"dataType"` option.  
+By default, the library will try to detect the data type automatically from the file extension, otherwise it is assumed to be `"json"`.
 
-- Type: `"json" | "csv" | "tsv" | "xml"`
-- Default: `"json"`
+- Type: `"json" | "csv" | "tsv" | "xml" | "auto"`
+- Default: `"auto"`
 - Example:
 
-This example uses `"csv"` data type
+These examples use `"csv"` data type
 
 ```js
-race('/data.csv', '#race', { dataType: 'csv' });
+race('/data.csv', '#race');
+race('/data', '#race', { dataType: 'csv' });
 ```
 
 ### dateCounter

--- a/website/docs/gallery/_gallery-demos.ts
+++ b/website/docs/gallery/_gallery-demos.ts
@@ -7,14 +7,12 @@ type ChartProps = Props & {
 export const autorunFalse: ChartProps = {
   label: 'Autorun disabled',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   autorun: false,
 };
 
 export const captionDataFunction: ChartProps = {
   label: 'Caption (data function)',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   caption: (_currentDate, dateSlice, _allDates) =>
     `Total: ${Math.round(dateSlice.reduce((acc, curr) => acc + curr.value, 0))}`,
   dynamicProps: {
@@ -26,14 +24,12 @@ export const captionDataFunction: ChartProps = {
 export const captionString: ChartProps = {
   label: 'Caption (string)',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   caption: 'Source: World Bank',
 };
 
 export const colorMapGroups: ChartProps = {
   label: 'Color Map for Groups',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   colorMap: {
     Asia: 'yellow',
@@ -45,7 +41,6 @@ export const colorMapGroups: ChartProps = {
 export const colorMap: ChartProps = {
   label: 'Color Map',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   colorMap: {
     India: 'orange',
@@ -57,7 +52,6 @@ export const colorMap: ChartProps = {
 export const colorPalette: ChartProps = {
   label: 'Color Palette',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   colorMap: [
     '#636EFA',
@@ -77,7 +71,6 @@ export const colorPalette: ChartProps = {
 export const colorSeedRandom: ChartProps = {
   label: 'Random Color Seed',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   colorSeed: Math.round(Math.random() * 100),
   dynamicProps: { colorSeed: 'Math.round(Math.random() * 100)' },
@@ -86,7 +79,6 @@ export const colorSeedRandom: ChartProps = {
 export const colorSeed: ChartProps = {
   label: 'Color Seed',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   colorSeed: 42,
   showGroups: false,
@@ -95,7 +87,6 @@ export const colorSeed: ChartProps = {
 export const controlButtonsAll: ChartProps = {
   label: 'Control Buttons: All',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   subTitle: 'in millions',
   controlButtons: 'all',
@@ -104,7 +95,6 @@ export const controlButtonsAll: ChartProps = {
 export const controlButtonsPlay: ChartProps = {
   label: 'Control Buttons: Play',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   subTitle: 'in millions',
   controlButtons: 'play',
@@ -113,7 +103,6 @@ export const controlButtonsPlay: ChartProps = {
 export const controlButtonsNone: ChartProps = {
   label: 'Control Buttons: None',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   subTitle: 'in millions',
   controlButtons: 'none',
@@ -122,7 +111,6 @@ export const controlButtonsNone: ChartProps = {
 export const cumulativeSum: ChartProps = {
   label: 'Cumulative Sum',
   dataUrl: '/data/gh-star.csv',
-  dataType: 'csv',
   title: 'Top Programming Languages',
   subTitle: 'Github Stars',
   makeCumulative: true,
@@ -131,7 +119,6 @@ export const cumulativeSum: ChartProps = {
 export const datasetBrands: ChartProps = {
   label: 'Brand Values Dataset',
   dataUrl: '/data/brands.csv',
-  dataType: 'csv',
   title: '18 years of Top Global Brands',
   subTitle: 'Brand value, $m',
   colorSeed: 45,
@@ -140,7 +127,6 @@ export const datasetBrands: ChartProps = {
 export const datasetCovid: ChartProps = {
   label: 'Covid-19 Dataset',
   dataUrl: '/data/covid-19.csv',
-  dataType: 'csv',
   title: 'Covid-19',
   subTitle: 'Number of confirmed cases',
   dateCounter: 'MMM DD, YYYY',
@@ -150,7 +136,6 @@ export const datasetCovid: ChartProps = {
 export const datasetGdp: ChartProps = {
   label: 'GDP Dataset',
   dataUrl: '/data/gdp.csv',
-  dataType: 'csv',
   dataTransform: (data) =>
     data.map((d) => ({
       ...d,
@@ -169,7 +154,6 @@ export const datasetGdp: ChartProps = {
 export const datasetGhPush: ChartProps = {
   label: 'GitHub Push Events Dataset',
   dataUrl: '/data/gh-push.csv',
-  dataType: 'csv',
   title: 'Top Programming Languages',
   subTitle: 'Github Push Events',
   dateCounter: (currentDate, _dateSlice, _allDates) => {
@@ -193,7 +177,6 @@ export const datasetGhPush: ChartProps = {
 export const datasetGhStars: ChartProps = {
   label: 'GitHub Stars Dataset',
   dataUrl: '/data/gh-star.csv',
-  dataType: 'csv',
   title: 'Top Programming Languages',
   subTitle: 'Github Stars',
   makeCumulative: true,
@@ -218,7 +201,6 @@ export const datasetGhStars: ChartProps = {
 export const datasetPopulation: ChartProps = {
   label: 'Population Dataset',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   dataTransform: (data) =>
     data.map((d) => ({
       ...d,
@@ -238,7 +220,6 @@ export const datasetPopulation: ChartProps = {
 export const dataTransform: ChartProps = {
   label: 'Data Transform',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   dataTransform: (data) =>
     data.map((d) => ({
       ...d,
@@ -255,14 +236,12 @@ export const dataTransform: ChartProps = {
 export const dateCounterFormat: ChartProps = {
   label: 'Date Counter (format)',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   dateCounter: 'MMM DD, YYYY 🌍',
 };
 
 export const dateCounterDataFunction: ChartProps = {
   label: 'Date Counter (data function)',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   dateCounter: (currentDate, _dateSlice, allDates) =>
     `${allDates.indexOf(currentDate) + 1} of ${allDates.length}`,
   dynamicProps: {
@@ -274,7 +253,6 @@ export const dateCounterDataFunction: ChartProps = {
 export const fillDateGapsNull: ChartProps = {
   label: 'Filling Date Gaps: null (default)',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   fillDateGapsInterval: null,
   dataTransform: function multiplyBy1000(data) {
     return data.map((d) => ({
@@ -295,7 +273,6 @@ return data.map((d) => ({
 export const fillDateGapsMonthInterpolate: ChartProps = {
   label: 'Filling Date Gaps: month - interpolate',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   fillDateGapsInterval: 'month',
   fillDateGapsValue: 'interpolate',
   dataTransform: function multiplyBy1000(data) {
@@ -317,7 +294,6 @@ return data.map((d) => ({
 export const fillDateGapsMonthLast: ChartProps = {
   label: 'Filling Date Gaps: month - last',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   fillDateGapsInterval: 'month',
   fillDateGapsValue: 'last',
   dataTransform: function multiplyBy1000(data) {
@@ -339,7 +315,6 @@ return data.map((d) => ({
 export const fixedOrder: ChartProps = {
   label: 'Fixed Order',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   dateCounter: 'YYYY',
   fixedOrder: ['Algeria', 'Italy', 'Canada', 'France', 'Argentina'],
   topN: 3,
@@ -349,7 +324,6 @@ export const fixedOrder: ChartProps = {
 export const fixedScale: ChartProps = {
   label: 'Fixed Scale',
   dataUrl: '/data/covid-19.csv',
-  dataType: 'csv',
   title: 'Covid-19 Confirmed Cases',
   fixedScale: true,
   labelsPosition: 'outside',
@@ -358,7 +332,6 @@ export const fixedScale: ChartProps = {
 export const highlightBars: ChartProps = {
   label: 'Highlight Bars',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   highlightBars: true,
 };
@@ -366,7 +339,6 @@ export const highlightBars: ChartProps = {
 export const icons: ChartProps = {
   label: 'Icons',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   dataTransform: (data) =>
     data.map((d) => ({
       ...d,
@@ -385,7 +357,6 @@ export const icons: ChartProps = {
 export const keyboardControls: ChartProps = {
   label: 'Keyboard Controls',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   keyboardControls: true,
 };
@@ -393,7 +364,6 @@ export const keyboardControls: ChartProps = {
 export const labelsPosition: ChartProps = {
   label: 'Labels Position',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   labelsPosition: 'outside',
 };
@@ -401,7 +371,6 @@ export const labelsPosition: ChartProps = {
 export const loop: ChartProps = {
   label: 'Loop',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   startDate: '1970-01-01',
   endDate: '1980-01-01',
@@ -411,7 +380,6 @@ export const loop: ChartProps = {
 export const margins: ChartProps = {
   label: 'Margins',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   marginTop: 40,
   marginBottom: 40,
@@ -423,7 +391,6 @@ export const margins: ChartProps = {
 export const mouseControls: ChartProps = {
   label: 'Mouse Controls',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   mouseControls: true,
   showGroups: true,
@@ -432,7 +399,6 @@ export const mouseControls: ChartProps = {
 export const overlays: ChartProps = {
   label: 'Overlays',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   overlays: 'all',
   autorun: false,
@@ -442,7 +408,6 @@ export const overlays: ChartProps = {
 export const selectBars: ChartProps = {
   label: 'Select Bars',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   selectBars: true,
 };
@@ -450,7 +415,6 @@ export const selectBars: ChartProps = {
 export const showGroups: ChartProps = {
   label: 'Show Groups',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   showGroups: true,
 };
@@ -458,7 +422,6 @@ export const showGroups: ChartProps = {
 export const startEndDates: ChartProps = {
   label: 'Start and End Dates',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   startDate: '1970-01-01',
   endDate: '1999-12-31',
@@ -467,7 +430,6 @@ export const startEndDates: ChartProps = {
 export const themeDark: ChartProps = {
   label: 'Dark Theme',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   theme: 'dark',
 };
@@ -475,7 +437,6 @@ export const themeDark: ChartProps = {
 export const tickDuration: ChartProps = {
   label: 'Chart Speed (tickDuration)',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   tickDuration: 100,
 };
@@ -483,7 +444,6 @@ export const tickDuration: ChartProps = {
 export const titleSubtitle: ChartProps = {
   label: 'Title and Sub-Title',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   subTitle: 'in millions',
 };
@@ -491,7 +451,6 @@ export const titleSubtitle: ChartProps = {
 export const topN: ChartProps = {
   label: 'Top N',
   dataUrl: '/data/population.csv',
-  dataType: 'csv',
   title: 'World Population',
   topN: 5,
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature & docs update

**What is the current behavior?**

`dataShape` and `dataType` have to be explicitly provided.

**What is the new behavior (if this is a feature change)?**

This PR introduces the default value: `"auto"` for both `dataShape` and `dataType`.

`dataShape` is detected by the data structure (after any transformation, by finding the columns `date`, `name` and `value`).

`dataType` is detected by file extension.

Both options can be overriden by explicitly providing another value.

**Issue related to this PR**

closes #178