### PR TITLE
Value decimals

### DIFF
--- a/src/lib/options/__tests__/validate-options.spec.ts
+++ b/src/lib/options/__tests__/validate-options.spec.ts
@@ -189,3 +189,20 @@ test('Tests to validate fillDateGapsValue option', () => {
   const invalidOpts = validateOptions(options);
   expect(invalidOpts.fillDateGapsValue).toBeUndefined();
 });
+
+test('Tests to validate valueDecimals option', () => {
+  // Valid options
+  const options: any = { valueDecimals: 'preserve' };
+  const validatedOpts = validateOptions(options);
+  expect(validatedOpts.valueDecimals).toBe('preserve');
+
+  // Valid options
+  const options2: any = { valueDecimals: 2 };
+  const validatedOpts2 = validateOptions(options2);
+  expect(validatedOpts2.valueDecimals).toBe(2);
+
+  // Invalid options
+  options.valueDecimals = 'invalid';
+  const invalidOpts = validateOptions(options);
+  expect(invalidOpts.valueDecimals).toBeUndefined();
+});

--- a/src/lib/options/__tests__/validate-options.spec.ts
+++ b/src/lib/options/__tests__/validate-options.spec.ts
@@ -206,3 +206,28 @@ test('Tests to validate valueDecimals option', () => {
   const invalidOpts = validateOptions(options);
   expect(invalidOpts.valueDecimals).toBeUndefined();
 });
+
+test('Tests to validate colorMap option', () => {
+  // Valid options
+  const options: any = { colorMap: ['blue', 'red'] };
+  const validatedOpts = validateOptions(options);
+  expect(validatedOpts.colorMap).toStrictEqual(['blue', 'red']);
+
+  // Valid options
+  const options2: any = {
+    colorMap: {
+      India: 'orange',
+      'United States': 'blue',
+    },
+  };
+  const validatedOpts2 = validateOptions(options2);
+  expect(validatedOpts2.colorMap).toStrictEqual({
+    India: 'orange',
+    'United States': 'blue',
+  });
+
+  // Invalid options
+  options.colorMap = 'invalid';
+  const invalidOpts = validateOptions(options);
+  expect(invalidOpts.colorMap).toBeUndefined();
+});

--- a/src/lib/options/options.models.ts
+++ b/src/lib/options/options.models.ts
@@ -9,6 +9,7 @@ export interface Options {
   dataShape: 'long' | 'wide' | 'auto';
   dataType: 'json' | 'csv' | 'tsv' | 'xml' | 'auto';
   dataTransform: null | ((data: Data[] | WideData[]) => Data[] | WideData[]);
+  valueDecimals: 'preserve' | number;
   fillDateGapsInterval: null | 'year' | 'month' | 'day';
   fillDateGapsValue: 'last' | 'interpolate';
   labelsPosition: 'inside' | 'outside' | 'none';

--- a/src/lib/options/options.reducer.ts
+++ b/src/lib/options/options.reducer.ts
@@ -7,6 +7,7 @@ export const defaultOptions: Options = {
   dataShape: 'auto',
   dataType: 'auto',
   dataTransform: null,
+  valueDecimals: 'preserve',
   fillDateGapsInterval: null,
   fillDateGapsValue: 'interpolate',
   makeCumulative: false,

--- a/src/lib/options/validate-options.ts
+++ b/src/lib/options/validate-options.ts
@@ -67,7 +67,7 @@ export function validateOptions(options: Partial<Options>): Partial<Options> {
   // Validate number options
   numberOpts.forEach((opt) => {
     if (!is(options[opt], 'number')) return;
-    newOptions[opt] = options[opt];
+    newOptions[opt] = Number(options[opt]);
   });
 
   // Validate string options
@@ -115,6 +115,13 @@ export function validateOptions(options: Partial<Options>): Partial<Options> {
 
   if (includes(validFillDateGapsValues, options.fillDateGapsValue)) {
     newOptions.fillDateGapsValue = options.fillDateGapsValue;
+  }
+
+  if (options.valueDecimals === 'preserve') {
+    newOptions.valueDecimals = 'preserve';
+  }
+  if (is(options.valueDecimals, 'number')) {
+    newOptions.valueDecimals = Number(options.valueDecimals);
   }
 
   // Validate array of options

--- a/src/lib/options/validate-options.ts
+++ b/src/lib/options/validate-options.ts
@@ -134,7 +134,9 @@ export function validateOptions(options: Partial<Options>): Partial<Options> {
     newOptions.dataTransform = options.dataTransform;
   }
 
-  validateColorMap(options.colorMap);
+  if (validateColorMap(options.colorMap)) {
+    newOptions.colorMap = options.colorMap;
+  }
 
   return newOptions;
 }

--- a/src/lib/race.ts
+++ b/src/lib/race.ts
@@ -176,6 +176,7 @@ export async function race(
         'startDate',
         'endDate',
         'fixedOrder',
+        'makeCumulative',
       ];
       let dataOptionsChanged = false;
       dataOptions.forEach((key) => {

--- a/src/lib/renderer/render-initial-view.ts
+++ b/src/lib/renderer/render-initial-view.ts
@@ -2,7 +2,7 @@ import * as d3 from '../d3';
 
 import type { Store } from '../store';
 import type { Data } from '../data';
-import { getDateSlice, getText, getColor, safeName, getIconID } from '../utils';
+import { getDateSlice, getText, getColor, safeName, getIconID, countDecimals } from '../utils';
 import type { RenderOptions } from './render-options';
 import { calculateDimensions } from './calculate-dimensions';
 import { renderHeader } from './render-header';
@@ -20,6 +20,7 @@ export function renderInitialView(data: Data[], store: Store, renderOptions: Ren
   const CompleteDateSlice = getDateSlice(currentDate, data, store);
   const dateSlice = CompleteDateSlice.slice(0, topN);
   const lastDateIndex = dates.indexOf(currentDate) > 0 ? dates.indexOf(currentDate) - 1 : 0;
+  const valueDecimals = store.getState().options.valueDecimals;
   renderOptions.lastDate = dates[lastDateIndex];
 
   if (!root || dateSlice.length === 0) return;
@@ -115,7 +116,11 @@ export function renderInitialView(data: Data[], store: Store, renderOptions: Ren
       .attr('class', 'valueLabel')
       .attr('x', (d: Data) => x(d.value) + 5)
       .attr('y', (d: Data) => barY(d) + barHalfHeight)
-      .text((d: Data) => d3.format(',.0f')(d.lastValue as number));
+      .text((d: Data) =>
+        valueDecimals === 'preserve'
+          ? d.lastValue
+          : d3.format(`,.${countDecimals(d.lastValue ?? d.value)}f`)(d.lastValue as number),
+      );
 
     if (showIcons) {
       const defs = (renderOptions.defs = svg.append('svg:defs'));

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -61,6 +61,8 @@ function toNumber(s: string | number) {
   return +nums;
 }
 
+export const countDecimals = (n: number) => String(n).split('.')[1]?.length || 0;
+
 export function random(InputSeed: string | number) {
   const seed = toNumber(InputSeed);
   const x = Math.sin(seed) * 10000;

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -25,6 +25,7 @@ const props = {
   dataTransform: [Function, Object], // Object for null
   fillDateGapsInterval: [String, Object], // Object for null
   fillDateGapsValue: String,
+  valueDecimals: Number,
   makeCumulative: String, // Boolean
   title: String,
   subTitle: String,

--- a/website/docs/documentation/options.md
+++ b/website/docs/documentation/options.md
@@ -844,6 +844,20 @@ const options = {
 };
 ```
 
+### valueDecimals
+
+Number of decimal places to display for values. By default (`"preserve"`), the values in the data are used as is.
+
+- Type: `number | "preserve"`
+- Default: `"preserve"`
+- Example: [view in gallery](../gallery/value-decimals.md)
+
+```js
+const options = {
+  valueDecimals: 0,
+};
+```
+
 ### width
 
 Specifies the width of the chart.

--- a/website/docs/gallery/_gallery-demos.ts
+++ b/website/docs/gallery/_gallery-demos.ts
@@ -329,7 +329,7 @@ export const labelsPosition: ChartProps = {
 };
 
 export const labelsPositionNone: ChartProps = {
-  label: 'Labels Position',
+  label: 'Hidden Labels',
   dataUrl: '/data/population.csv',
   dataTransform: (data) =>
     data.map((d) => ({

--- a/website/docs/gallery/_gallery-demos.ts
+++ b/website/docs/gallery/_gallery-demos.ts
@@ -254,20 +254,6 @@ export const fillDateGapsNull: ChartProps = {
   label: 'Filling Date Gaps: null (default)',
   dataUrl: '/data/population.csv',
   fillDateGapsInterval: null,
-  dataTransform: function multiplyBy1000(data) {
-    return data.map((d) => ({
-      ...d,
-      value: Number(d.value) * 1000,
-    }));
-  },
-  dynamicProps: {
-    dataTransform: `function multiplyBy1000(data) {
-return data.map((d) => ({
-  ...d,
-  value: Number(d.value) * 1000,
-}));
-}`,
-  },
 };
 
 export const fillDateGapsMonthInterpolate: ChartProps = {
@@ -275,20 +261,7 @@ export const fillDateGapsMonthInterpolate: ChartProps = {
   dataUrl: '/data/population.csv',
   fillDateGapsInterval: 'month',
   fillDateGapsValue: 'interpolate',
-  dataTransform: function multiplyBy1000(data) {
-    return data.map((d) => ({
-      ...d,
-      value: Number(d.value) * 1000,
-    }));
-  },
-  dynamicProps: {
-    dataTransform: `function multiplyBy1000(data) {
-return data.map((d) => ({
-  ...d,
-  value: Number(d.value) * 1000,
-}));
-}`,
-  },
+  valueDecimals: 2,
 };
 
 export const fillDateGapsMonthLast: ChartProps = {
@@ -296,20 +269,7 @@ export const fillDateGapsMonthLast: ChartProps = {
   dataUrl: '/data/population.csv',
   fillDateGapsInterval: 'month',
   fillDateGapsValue: 'last',
-  dataTransform: function multiplyBy1000(data) {
-    return data.map((d) => ({
-      ...d,
-      value: Number(d.value) * 1000,
-    }));
-  },
-  dynamicProps: {
-    dataTransform: `function multiplyBy1000(data) {
-return data.map((d) => ({
-  ...d,
-  value: Number(d.value) * 1000,
-}));
-}`,
-  },
+  valueDecimals: 2,
 };
 
 export const fixedOrder: ChartProps = {

--- a/website/docs/gallery/_gallery-demos.ts
+++ b/website/docs/gallery/_gallery-demos.ts
@@ -470,3 +470,10 @@ export const topN: ChartProps = {
   title: 'World Population',
   topN: 5,
 };
+
+export const valueDecimals: ChartProps = {
+  label: 'Value Decimals',
+  dataUrl: '/data/population.csv',
+  title: 'World Population',
+  valueDecimals: 3,
+};

--- a/website/docs/gallery/value-decimals.md
+++ b/website/docs/gallery/value-decimals.md
@@ -1,0 +1,19 @@
+---
+title: Value Decimals
+hide_table_of_contents: true
+---
+
+import RacingBars from '../../src/components/RacingBars';
+import { valueDecimals } from './\_gallery-demos.ts';
+
+A demo for using [`valueDecimals`](../documentation/options.md#valuedecimals) to control the number of decimal places to display for values.
+
+<!--truncate-->
+
+### Chart
+
+<div className="gallery">
+  <RacingBars
+    {...valueDecimals}
+  />
+</div>

--- a/website/docs/guides/colors.md
+++ b/website/docs/guides/colors.md
@@ -1,0 +1,5 @@
+---
+title: Colors
+---
+
+TODO...

--- a/website/docs/guides/data-transformation.md
+++ b/website/docs/guides/data-transformation.md
@@ -28,6 +28,8 @@ const options = {
 race('/data/population.csv', '#race', options);
 ```
 
+[View in gallery](../gallery/data-transform.md)
+
 ## Manually loading and transforming data
 
 The [`loadData`](../documentation/api.md#loaddata) function can be used to load data. It can then be transformed before it is used in the chart.
@@ -49,6 +51,42 @@ const options = {
 race(transformedData, '#race', options);
 ```
 
+## `startDate` and `endDate` options
+
+The data can be filtered by setting the [`startDate`](../documentation/options.md#startDate) and [`endDate`](../documentation/options.md#endDate) options.
+
+```js
+import { race } from 'racing-bars';
+
+const options = {
+  title: 'World Population',
+  startDate: '1970-01-01',
+  endDate: '1999-12-31',
+};
+
+race('/data/population.csv', '#race', options);
+```
+
+[View in gallery](../gallery/start-end-dates.md)
+
+## `makeCumulative` option
+
+The data values can be converted to cumulative sums (running totals) by setting the [`makeCumulative`](../documentation/options.md#makecummulative) option to `true`.
+
+```js
+import { race } from 'racing-bars';
+
+const options = {
+  title: 'Github Stars',
+  makeCumulative: true,
+  // ...
+};
+
+race('/data/gh-star.csv', '#race', options);
+```
+
+[View in gallery](../gallery/data-gh-star.md)
+
 ## `valueDecimals` option
 
 In case you just need to control the number of decimal places to display for values, you do not need to transform the data. You may just use the [`valueDecimals`](../documentation/options.md#valuedecimals) option.
@@ -64,3 +102,24 @@ const options = {
 
 race('/data/population.csv', '#race', options);
 ```
+
+[View in gallery](../gallery/value-decimals.md)
+
+## Filling gaps in data
+
+Dates that are missing from data will be skipped.
+If you need to fill date gaps, you may use the options [`fillDateGapsInterval`](./options.md#filldategapsinterval) and [`fillDateGapValue`](./options.md#filldategapsvalue).
+
+```js
+import { race } from 'racing-bars';
+
+const options = {
+  fillDateGapsInterval: 'month',
+  fillDateGapsValue: 'interpolate',
+  valueDecimals: 2,
+};
+
+race('/data/population.csv', '#race', options);
+```
+
+[View in gallery](../gallery/fill-date-gaps.md)

--- a/website/docs/guides/data-transformation.md
+++ b/website/docs/guides/data-transformation.md
@@ -1,0 +1,66 @@
+---
+title: Data Transformation
+---
+
+By, default, the [loaded data](../documentation/data.md) is used as is.
+
+However, it is possible to transform the data before it is used in the chart, by one of these ways:
+
+## `dataTransform` function
+
+The [chart options](../documentation/options.md) can have a [`dataTransform`](../documentation/options.md#datatransform) function which can be used to transform the data before it is used in the chart. It receives the loaded data and returns the transformed data.
+
+Example:
+
+```js
+import { race } from 'racing-bars';
+
+const options = {
+  dataTransform: (data) =>
+    data.map((d) => ({
+      ...d,
+      icon: `https://flagsapi.com/${d.code}/flat/64.png`,
+    })),
+  title: 'World Population',
+  // ...
+};
+
+race('/data/population.csv', '#race', options);
+```
+
+## Manually loading and transforming data
+
+The [`loadData`](../documentation/api.md#loaddata) function can be used to load data. It can then be transformed before it is used in the chart.
+
+```js
+import { loadData, race } from 'racing-bars';
+
+const data = await loadData('/data/population.csv', 'csv');
+const transformedData = data.map((d) => ({
+  ...d,
+  icon: `https://flagsapi.com/${d.code}/flat/64.png`,
+}));
+
+const options = {
+  title: 'World Population',
+  // ...
+};
+
+race(transformedData, '#race', options);
+```
+
+## `valueDecimals` option
+
+In case you just need to control the number of decimal places to display for values, you do not need to transform the data. You may just use the [`valueDecimals`](../documentation/options.md#valuedecimals) option.
+
+```js
+import { race } from 'racing-bars';
+
+const options = {
+  title: 'World Population',
+  valueDecimals: 0,
+  // ...
+};
+
+race('/data/population.csv', '#race', options);
+```

--- a/website/docs/guides/data-transformation.md
+++ b/website/docs/guides/data-transformation.md
@@ -108,7 +108,7 @@ race('/data/population.csv', '#race', options);
 ## Filling gaps in data
 
 Dates that are missing from data will be skipped.
-If you need to fill date gaps, you may use the options [`fillDateGapsInterval`](./options.md#filldategapsinterval) and [`fillDateGapValue`](./options.md#filldategapsvalue).
+If you need to fill date gaps, you may use the options [`fillDateGapsInterval`](../documentation/options.md#filldategapsinterval) and [`fillDateGapValue`](../documentation/options.md#filldategapsvalue).
 
 ```js
 import { race } from 'racing-bars';

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -5,9 +5,7 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
  - create an ordered group of docs
  - render a sidebar for each doc of that group
  - provide next/previous navigation
- 
   The sidebars can be generated from the filesystem, or explicitly defined here.
- 
   Create as many sidebars as you want.
  */
 const sidebars: SidebarsConfig = {

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -5,9 +5,9 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
  - create an ordered group of docs
  - render a sidebar for each doc of that group
  - provide next/previous navigation
-
+ 
   The sidebars can be generated from the filesystem, or explicitly defined here.
-
+ 
   Create as many sidebars as you want.
  */
 const sidebars: SidebarsConfig = {

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -5,9 +5,9 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
  - create an ordered group of docs
  - render a sidebar for each doc of that group
  - provide next/previous navigation
- 
+
  The sidebars can be generated from the filesystem, or explicitly defined here.
- 
+
  Create as many sidebars as you want.
  */
 const sidebars: SidebarsConfig = {
@@ -59,6 +59,7 @@ const sidebars: SidebarsConfig = {
         type: 'generated-index',
       },
       items: [
+        'guides/data-transformation',
         'guides/chart-size',
         'guides/bar-colors',
         'guides/themes-styles',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -6,9 +6,9 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
  - render a sidebar for each doc of that group
  - provide next/previous navigation
 
- The sidebars can be generated from the filesystem, or explicitly defined here.
+  The sidebars can be generated from the filesystem, or explicitly defined here.
 
- Create as many sidebars as you want.
+  Create as many sidebars as you want.
  */
 const sidebars: SidebarsConfig = {
   docsSidebar: [


### PR DESCRIPTION
This PR allows and controls showing decimal places in values, by adding a new option `valueDecimals`. It can be set to any number of decimals. `0` shows no decimals. By default, it is set to `"preserve"` which show the values from data as is.

fixes #177 