### PR TITLE
add `valueLocale` option

### DIFF
--- a/demo/value-locale.html
+++ b/demo/value-locale.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<head> </head>
+
+<body>
+  <div id="race" style="width: 50vw; height: 70vh"></div>
+
+  <script type="module">
+    import { race } from '../build/racing-bars.js';
+
+    race('../data/population.json', '#race', {
+      valueLocale: 'de-DE',
+      valueDecimals: 0,
+    });
+  </script>
+</body>

--- a/src/lib/d3.ts
+++ b/src/lib/d3.ts
@@ -3,7 +3,6 @@ export {
   axisTop,
   csv,
   easeLinear,
-  format,
   hsl,
   interpolate,
   interpolateRound,

--- a/src/lib/options/options.models.ts
+++ b/src/lib/options/options.models.ts
@@ -10,6 +10,7 @@ export interface Options {
   dataType: 'json' | 'csv' | 'tsv' | 'xml' | 'auto';
   dataTransform: null | ((data: Data[] | WideData[]) => Data[] | WideData[]);
   valueDecimals: 'preserve' | number;
+  valueLocale: string;
   fillDateGapsInterval: null | 'year' | 'month' | 'day';
   fillDateGapsValue: 'last' | 'interpolate';
   labelsPosition: 'inside' | 'outside' | 'none';

--- a/src/lib/options/options.reducer.ts
+++ b/src/lib/options/options.reducer.ts
@@ -7,6 +7,7 @@ export const defaultOptions: Options = {
   dataShape: 'auto',
   dataType: 'auto',
   dataTransform: null,
+  valueLocale: 'en-US',
   valueDecimals: 'preserve',
   fillDateGapsInterval: null,
   fillDateGapsValue: 'interpolate',

--- a/src/lib/options/validate-options.ts
+++ b/src/lib/options/validate-options.ts
@@ -24,7 +24,9 @@ const numberOpts = [
   'marginBottom',
   'marginLeft',
 ] as const satisfies Array<keyof Options>;
-const strOpts = ['theme', 'startDate', 'endDate'] as const satisfies Array<keyof Options>;
+const strOpts = ['valueLocale', 'theme', 'startDate', 'endDate'] as const satisfies Array<
+  keyof Options
+>;
 const strOrNumberOpts = [
   'colorSeed',
   'inputHeight',

--- a/src/lib/renderer/render-frame.ts
+++ b/src/lib/renderer/render-frame.ts
@@ -2,7 +2,7 @@ import * as d3 from '../d3';
 
 import type { Data } from '../data';
 import type { Store } from '../store';
-import { getDateSlice, safeName, getColor, getIconID, getText, countDecimals } from '../utils';
+import { getDateSlice, safeName, getColor, getIconID, getText } from '../utils';
 import type { RenderOptions } from './render-options';
 import { selectFn, highlightFn, halo } from './helpers';
 import { updateControls } from './controls';
@@ -51,6 +51,16 @@ export function renderFrame(data: Data[], store: Store, renderOptions: RenderOpt
   const CompleteDateSlice = getDateSlice(currentDate, data, store);
   const dateSlice = CompleteDateSlice.slice(0, topN);
   const valueDecimals = store.getState().options.valueDecimals;
+  const valueLocale = store.getState().options.valueLocale;
+  const valueLocaleter = new Intl.NumberFormat(
+    valueLocale,
+    valueDecimals === 'preserve'
+      ? {}
+      : {
+          minimumFractionDigits: valueDecimals,
+          maximumFractionDigits: valueDecimals,
+        },
+  );
 
   if (showGroups) {
     svg
@@ -155,11 +165,7 @@ export function renderFrame(data: Data[], store: Store, renderOptions: RenderOpt
     .attr('class', 'valueLabel')
     .attr('x', (d: Data) => x(d.value) + 5)
     .attr('y', () => y(topN + 1) + marginBottom + 5)
-    .text((d: Data) =>
-      valueDecimals === 'preserve'
-        ? d.lastValue
-        : d3.format(`,.${countDecimals(d.lastValue ?? d.value)}f`)(d.lastValue as number),
-    )
+    .text((d: Data) => valueLocaleter.format(d.lastValue as number))
     .transition()
     .duration(tickDuration)
     .ease(d3.easeLinear)
@@ -176,11 +182,7 @@ export function renderFrame(data: Data[], store: Store, renderOptions: RenderOpt
       const lastValue = Number(sameDate ? d.value : (d.lastValue as number)) || 0;
       const i = d3.interpolate(lastValue, d.value);
       return function (t: number) {
-        const decimals =
-          valueDecimals === 'preserve'
-            ? Math.max(countDecimals(d.value), countDecimals(lastValue))
-            : valueDecimals;
-        this.textContent = d3.format(`,.${decimals || 0}f`)(i(t));
+        this.textContent = valueLocaleter.format(i(t));
       };
     });
 

--- a/src/lib/renderer/render-initial-view.ts
+++ b/src/lib/renderer/render-initial-view.ts
@@ -2,7 +2,7 @@ import * as d3 from '../d3';
 
 import type { Store } from '../store';
 import type { Data } from '../data';
-import { getDateSlice, getText, getColor, safeName, getIconID, countDecimals } from '../utils';
+import { getDateSlice, getText, getColor, safeName, getIconID } from '../utils';
 import type { RenderOptions } from './render-options';
 import { calculateDimensions } from './calculate-dimensions';
 import { renderHeader } from './render-header';
@@ -21,6 +21,16 @@ export function renderInitialView(data: Data[], store: Store, renderOptions: Ren
   const dateSlice = CompleteDateSlice.slice(0, topN);
   const lastDateIndex = dates.indexOf(currentDate) > 0 ? dates.indexOf(currentDate) - 1 : 0;
   const valueDecimals = store.getState().options.valueDecimals;
+  const valueLocale = store.getState().options.valueLocale;
+  const valueLocaleter = new Intl.NumberFormat(
+    valueLocale,
+    valueDecimals === 'preserve'
+      ? {}
+      : {
+          minimumFractionDigits: valueDecimals,
+          maximumFractionDigits: valueDecimals,
+        },
+  );
   renderOptions.lastDate = dates[lastDateIndex];
 
   if (!root || dateSlice.length === 0) return;
@@ -66,7 +76,9 @@ export function renderInitialView(data: Data[], store: Store, renderOptions: Ren
       .axisTop(x)
       .ticks(width > 500 ? 5 : 2)
       .tickSize(-(height - (margin.top + margin.bottom)))
-      .tickFormat((n: number | { valueOf(): number }) => d3.format(',')(n)));
+      .tickFormat((n: number | { valueOf(): number }) =>
+        new Intl.NumberFormat(valueLocale).format(typeof n === 'number' ? n : n.valueOf()),
+      ));
 
     svg
       .append('g')
@@ -116,11 +128,7 @@ export function renderInitialView(data: Data[], store: Store, renderOptions: Ren
       .attr('class', 'valueLabel')
       .attr('x', (d: Data) => x(d.value) + 5)
       .attr('y', (d: Data) => barY(d) + barHalfHeight)
-      .text((d: Data) =>
-        valueDecimals === 'preserve'
-          ? d.lastValue
-          : d3.format(`,.${countDecimals(d.lastValue ?? d.value)}f`)(d.lastValue as number),
-      );
+      .text((d: Data) => valueLocaleter.format(d.lastValue as number));
 
     if (showIcons) {
       const defs = (renderOptions.defs = svg.append('svg:defs'));

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -61,8 +61,6 @@ function toNumber(s: string | number) {
   return +nums;
 }
 
-export const countDecimals = (n: number) => String(n).split('.')[1]?.length || 0;
-
 export function random(InputSeed: string | number) {
   const seed = toNumber(InputSeed);
   const x = Math.sin(seed) * 10000;

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -26,6 +26,7 @@ const props = {
   fillDateGapsInterval: [String, Object], // Object for null
   fillDateGapsValue: String,
   valueDecimals: Number,
+  valueLocale: String,
   makeCumulative: String, // Boolean
   title: String,
   subTitle: String,

--- a/website/docs/documentation/options.md
+++ b/website/docs/documentation/options.md
@@ -858,6 +858,20 @@ const options = {
 };
 ```
 
+### valueLocale
+
+A string with a [BCP 47 language tag](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag) that specifies the locale used for the number format of bar values.
+
+- Type: `string`
+- Default: `"en-US"`
+- Example:
+
+```js
+const options = {
+  valueLocale: 'de-DE',
+};
+```
+
 ### width
 
 Specifies the width of the chart.

--- a/website/docs/gallery/_gallery-demos.ts
+++ b/website/docs/gallery/_gallery-demos.ts
@@ -372,6 +372,50 @@ export const mouseControls: ChartProps = {
   showGroups: true,
 };
 
+export const valueLocaleEn: ChartProps = {
+  label: 'Number Format',
+  dataUrl: '/data/population.csv',
+  title: 'World Population',
+  valueLocale: 'de-DE',
+  valueDecimals: 2,
+  dataTransform: (data) =>
+    data.map((d) => ({
+      ...d,
+      icon: `https://flagsapi.com/${d.code}/flat/64.png`,
+    })),
+  showIcons: true,
+  labelsPosition: 'none',
+  caption: (_currentDate, dateSlice, _allDates) =>
+    `Total: ${new Intl.NumberFormat('en-US').format(Math.round(dateSlice.reduce((acc, curr) => acc + curr.value, 0)))}`,
+  dynamicProps: {
+    caption: `(currentDate, dateSlice, allDates) =>
+\`Total: \${new Intl.NumberFormat('en-US').format(Math.round(dateSlice.reduce((acc, curr) => acc + curr.value, 0)))}\``,
+    dataTransform: `(data) => data.map((d) => ({ ...d, icon: \`https://flagsapi.com/\${d.code}/flat/64.png\` }))`,
+  },
+};
+
+export const valueLocaleDe: ChartProps = {
+  label: 'Number Format',
+  dataUrl: '/data/population.csv',
+  title: 'die Weltbevölkerung',
+  valueLocale: 'de-DE',
+  valueDecimals: 2,
+  dataTransform: (data) =>
+    data.map((d) => ({
+      ...d,
+      icon: `https://flagsapi.com/${d.code}/flat/64.png`,
+    })),
+  showIcons: true,
+  labelsPosition: 'none',
+  caption: (_currentDate, dateSlice, _allDates) =>
+    `Gesamt: ${new Intl.NumberFormat('de-DE').format(Math.round(dateSlice.reduce((acc, curr) => acc + curr.value, 0)))}`,
+  dynamicProps: {
+    caption: `(currentDate, dateSlice, allDates) =>
+\`Gesamt: \${new Intl.NumberFormat('de-DE').format(Math.round(dateSlice.reduce((acc, curr) => acc + curr.value, 0)))}\``,
+    dataTransform: `(data) => data.map((d) => ({ ...d, icon: \`https://flagsapi.com/\${d.code}/flat/64.png\` }))`,
+  },
+};
+
 export const overlays: ChartProps = {
   label: 'Overlays',
   dataUrl: '/data/population.csv',

--- a/website/docs/gallery/value-locale.md
+++ b/website/docs/gallery/value-locale.md
@@ -1,0 +1,34 @@
+---
+title: Value Locale
+hide_table_of_contents: true
+---
+
+import RacingBars from '../../src/components/RacingBars';
+import { valueLocaleEn, valueLocaleDe } from './\_gallery-demos.ts';
+
+A demo for using [`valueLocale`](../documentation/options.md#valueLocale) to control number format of bar values.
+
+<!--truncate-->
+
+## valueLocale: "en-US" (default)
+
+### Chart
+
+<div className="gallery">
+  <RacingBars
+    {...valueLocaleEn}
+    valueLocale={'en-US'}
+/>
+
+</div>
+
+## valueLocale: "de-DE"
+
+### Chart
+
+<div className="gallery">
+  <RacingBars
+    {...valueLocaleDe}
+    valueLocale={'de-DE'}
+  />
+</div>


### PR DESCRIPTION
This PR adds a new option `valueLocale` which allows setting the locale for number format of bar values
e.g. `de-DE`

The default value is `en-US`

Closes #215 